### PR TITLE
 Prevent default behaviour for anchor tag

### DIFF
--- a/angular-drag-and-drop-lists.js
+++ b/angular-drag-and-drop-lists.js
@@ -146,7 +146,7 @@ angular.module('dndLists', [])
         scope.$apply(function() {
           $parse(attr.dndSelected)(scope, {event: event});
         });
-
+        event.preventDefault();
         event.stopPropagation();
       });
 


### PR DESCRIPTION
When dndDraggable directive is added to anchor tag, and when user click on anchor then giving issue so added event.preventDefault();  at click event in dndDraggable directive.
